### PR TITLE
Update GitHub action versions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -20,14 +20,14 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       if: inputs.install_dependencies == 'true'
       with:
         cache: npm
         node-version: ${{ inputs.node_version }}
         registry-url: ${{ inputs.registry_url }}
     - name: Setup Node.js without cache
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       if: inputs.install_dependencies == 'false'
       with:
         node-version: ${{ inputs.node_version }}

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup
         uses: ./.github/actions/setup
         with:

--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -38,7 +38,7 @@ jobs:
         id: meta
         run: echo "tgz=$(ls *.tgz | head -n1)" >> $GITHUB_OUTPUT
       - name: Publish
-        uses: JS-DevTools/npm-publish@v2
+        uses: JS-DevTools/npm-publish@v3
         with:
           access: public
           token: ${{ secrets.registry_token }}

--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup
         uses: ./.github/actions/setup
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,7 +33,7 @@ jobs:
             os_name: Windows
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup
         uses: ./.github/actions/setup
         with:
@@ -52,7 +52,7 @@ jobs:
           - '20'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup
         uses: ./.github/actions/setup
         with:
@@ -129,7 +129,7 @@ jobs:
           - '20'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup
         uses: ./.github/actions/setup
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -95,7 +95,7 @@ jobs:
           name: ${{ needs.build.outputs.artifact_name }}
           path: .
       - name: Find packages
-        uses: tj-actions/glob@v16
+        uses: tj-actions/glob@v17
         id: packages
         with:
           files: '*.tgz'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -86,7 +86,7 @@ jobs:
             os_name: Windows
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - name: Download artifact

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -19,7 +19,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_TOKEN }}
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@v6
         with:
           git_user_signingkey: true
           git_commit_gpgsign: true

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Format
         run: npm run format
       - name: Commit
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         if: always()
         with:
           commit_message: Run format

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -19,7 +19,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_TOKEN }}
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@v6
         with:
           git_user_signingkey: true
           git_commit_gpgsign: true

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Normalize package-lock.json
         run: npm install
       - name: Commit
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Generate code
           commit_user_name: ${{ secrets.GIT_USER_NAME }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_TOKEN }}
       - name: Import GPG key

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN }}
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@v6
         with:
           git_user_signingkey: true
           git_commit_gpgsign: true


### PR DESCRIPTION
- Use checkout v4 action
- Use setup-node v4
- Use ghaction-import-gpg v6
- Use npm-publish v3 action
- Use git-auto-commit-action v5
- Use glob v17 action
